### PR TITLE
Add 100ms delay before requeue

### DIFF
--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -479,6 +479,9 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
 
                 $this->djLog(__('Will retry job {0}', $job->getId()));
 
+                // Sleep 100ms before requeuing the job... sometimes RabbitMQ is just too fast.
+                usleep(100 * 1000);
+
                 $this->requeueJob($job);
 
                 return;


### PR DESCRIPTION
... because RabbitMQ appears to sometimes be too fast for poor old MySQL.