### PR TITLE
Fix orphaning of jobs

### DIFF
--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -317,8 +317,6 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             $this->enqueueNextSequence($job);
         }
         $this->_persistToDatastore($job);
-
-        return $result;
     }
 
     /**
@@ -373,7 +371,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             $duration = round((microtime(true) - $start) * 1000); //Duration in milliseconds
             $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobExecute', [$result, $duration]);
 
-            return $this->_handleResult($result, $duration);
+            $this->_handleResult($result, $duration);
         }
     }
 
@@ -410,7 +408,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             return false;
         }
 
-        return $this->_executeJob($job, $jobWorker);
+        $this->_executeJob($job, $jobWorker);
     }
 
     public function enqueueNextSequence(Job $job)

--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -75,7 +75,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
         $this->_datastore = $datastore;
         $this->_messageBroker = $messageBroker;
 
-        $this->setConfig($config);
+        $this->config($config);
     }
 
     /**
@@ -107,7 +107,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             return $this->_datastore;
         }
 
-        $config = $this->getConfig('datasource');
+        $config = $this->config('datasource');
         $this->_datastore = new $config['className']($config, $this);
 
         return $this->_datastore;
@@ -122,7 +122,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             return $this->_messageBroker;
         }
 
-        $config = $this->getConfig('messageBroker');
+        $config = $this->config('messageBroker');
         $this->_messageBroker = new $config['className']($config, $this);
 
         return $this->_messageBroker;
@@ -192,8 +192,8 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
 
     protected function _calculateRetryTime($retryCount): Time
     {
-        if ($this->getConfig('DelayedJobs.retryTimes.' . $retryCount)) {
-            $growthFactor = $this->getConfig('DelayedJobs.retryTimes.' . $retryCount);
+        if ($this->config('DelayedJobs.retryTimes.' . $retryCount)) {
+            $growthFactor = $this->config('DelayedJobs.retryTimes.' . $retryCount);
         } else {
             $growthFactor = static::BASE_RETRY_TIME + $retryCount ** static::RETRY_FACTOR;
         }

--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -372,6 +372,8 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobExecute', [$result, $duration]);
 
             $this->_handleResult($result, $duration);
+
+            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobCompleted');
         }
     }
 

--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -371,7 +371,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
 
             $this->_handleResult($result, $duration);
 
-            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobCompleted');
+            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobCompleted', [$result]);
         }
     }
 

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -176,6 +176,7 @@ class WorkerShell extends AppShell
         $this->_manager = JobManager::instance();
         $this->_manager->eventManager()->on('DelayedJob.beforeJobExecute', [$this, 'beforeExecute']);
         $this->_manager->eventManager()->on('DelayedJob.afterJobExecute', [$this, 'afterExecute']);
+        $this->_manager->eventManager()->on('DelayedJob.afterJobCompleted', [$this, 'afterCompleted']);
         $this->_manager->eventManager()->on('DelayedJob.heartbeat', [$this, 'heartbeat']);
 
         $this->_manager->startConsuming();
@@ -311,7 +312,10 @@ class WorkerShell extends AppShell
             ));
             $this->out(sprintf('%s %d %.2fs (%s)', $fin, $job->getId(), $duration / 1000, $this->_makeReadable($nowMem)));
         }
+    }
 
+    public function afterCompleted()
+    {
         $this->_timeOfLastJob = microtime(true);
         $this->_checkSuicideStatus();
 


### PR DESCRIPTION
This PR introduces the dispatching of a new event, namely `DelayedJob.afterJobCompleted`.  It is dispatched after `_handleResult()` is called in order to ensure that a job's final data is fully persisted before any pcntl signals are handled.  This should prevent the last job before worker suicide or e.g. processing of SIGTERM from sitting in a status 2 (i.e. BUSY) state permanently.