### PR TITLE
Result factory

### DIFF
--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -395,7 +395,10 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             ->setDuration($duration)
             ->addHistory($result->getMessage(), $context);
 
-        if ($result->getRetry() && $job->getRetries() < $job->getMaxRetries()) {
+        if ($job->getStatus() === Job::STATUS_FAILED &&
+            $result->getRetry() &&
+            $job->getRetries() < $job->getMaxRetries()
+        ) {
             $job->incrementRetries();
 
             $retryTime = $result->getRecur();
@@ -406,6 +409,8 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             $this->enqueue($job);
 
             return;
+        } elseif ($job->getStatus() === Job::STATUS_FAILED) {
+            $job->getStatus(Job::STATUS_BURIED);
         }
 
         $this->_persistToDatastore($job);

--- a/src/DelayedJob/JobManager.php
+++ b/src/DelayedJob/JobManager.php
@@ -16,7 +16,6 @@ use DelayedJobs\Datasource\DatasourceInterface;
 use DelayedJobs\Datasource\TableDatasource;
 use DelayedJobs\DelayedJob\Exception\EnqueueException;
 use DelayedJobs\DelayedJob\Exception\JobExecuteException;
-use DelayedJobs\Exception\BrokerReconnectionException;
 use DelayedJobs\Exception\NonRetryableException;
 use DelayedJobs\Exception\PausedException;
 use DelayedJobs\Result\Failed;
@@ -351,30 +350,40 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
     {
         if ($result instanceof ResultInterface) {
             return $result;
-        } elseif ($result instanceof \DateTimeInterface) {
-            return (new Success($job, "Reoccur at {$result}"))->willRecur($result);
-        } elseif ($result instanceof PausedException) {
-            return new Pause($job, 'Execution paused');
-        } elseif ($result instanceof \Error || $result instanceof NonRetryableException) {
-            return (new Failed($job, $result->getMessage()))->willRetry(false)
-                ->setException($result);
-        } elseif ($result instanceof \Exception) {
-            return (new Failed($job, $result->getMessage()))->willRetry($job->getRetries() < $job->getMaxRetries())
+        }
+
+        if ($result instanceof \DateTimeInterface) {
+            return Success::create("Reoccur at {$result}")
+                ->willRecur($result);
+        }
+
+        if ($result instanceof PausedException) {
+            return new Pause('Execution paused');
+        }
+
+        if ($result instanceof \Error || $result instanceof NonRetryableException) {
+            return Failed::create($result->getMessage())
+                ->willRetry(false)
                 ->setException($result);
         }
 
-        return new Success($job, $result);
+        if ($result instanceof \Exception) {
+            return Failed::create($result->getMessage())
+                ->willRetry($job->getRetries() < $job->getMaxRetries())
+                ->setException($result);
+        }
+
+        return new Success($result);
     }
 
     /**
+     * @param \DelayedJobs\DelayedJob\Job $job The job
      * @param \DelayedJobs\Result\ResultInterface $result
      * @param $duration
      * @return void
      */
-    protected function _handleResult(ResultInterface $result, $duration)
+    protected function _handleResult(Job $job, ResultInterface $result, $duration)
     {
-        $job = $result->getJob();
-
         $context = ['enqueuedJobs' => $this->_enqueuedJobs];
 
         if ($result instanceof Failed && $result->getException()) {
@@ -386,7 +395,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             ->setDuration($duration)
             ->addHistory($result->getMessage(), $context);
 
-        if ($result->canRetry()) {
+        if ($result->getRetry() && $job->getRetries() < $job->getMaxRetries()) {
             $job->incrementRetries();
 
             $retryTime = $result->getRecur();
@@ -405,7 +414,7 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             $this->_enqueueRecurring($job, $result->getRecur());
         }
 
-        if ($job->getSequence() !== null && in_array($job->getStatus(), [Job::STATUS_SUCCESS, Job::STATUS_BURIED])) {
+        if ($job->getSequence() !== null && \in_array($job->getStatus(), [Job::STATUS_SUCCESS, Job::STATUS_BURIED])) {
             $this->enqueueNextSequence($job);
         }
     }
@@ -472,11 +481,11 @@ class JobManager implements EventDispatcherInterface, ManagerInterface
             }
 
             $duration = round((microtime(true) - $start) * 1000); //Duration in milliseconds
-            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobExecute', [$result, $duration]);
+            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobExecute', [$job, $result, $duration]);
 
-            $this->_handleResult($result, $duration);
+            $this->_handleResult($job, $result, $duration);
 
-            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobCompleted', [$result]);
+            $this->_dispatchWorkerEvent($jobWorker, 'DelayedJob.afterJobCompleted', [$job, $result]);
 
             $this->_currentJob = null;
             $this->_enqueuedJobs = [];

--- a/src/Result/Pause.php
+++ b/src/Result/Pause.php
@@ -20,7 +20,7 @@ class Pause extends Result
     /**
      * @return bool
      */
-    public function canRetry(): bool
+    public function getRetry(): bool
     {
         return false;
     }

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -25,7 +25,6 @@ abstract class Result implements ResultInterface
     /**
      * Result constructor.
      *
-     * @param \DelayedJobs\DelayedJob\Job $job The job
      * @param string $message The message
      */
     public function __construct($message = '')

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -33,7 +33,7 @@ abstract class Result implements ResultInterface
     }
 
     /**
-     * @param string $message
+     * @param string $message The message
      * @param string $class Class name to use (Either a FQCN, or a Cake style class)
      *
      * @return static
@@ -55,7 +55,7 @@ abstract class Result implements ResultInterface
     }
 
     /**
-     * @param string $message
+     * @param string $message The message
      * @return self
      */
     public function setMessage(string $message = ''): Result

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -34,9 +34,8 @@ abstract class Result implements ResultInterface
     }
 
     /**
-     * @param string $class Class name to use (Either a FQCN, or a Cake style class)
-     * @param \DelayedJobs\DelayedJob\Job $job Job this is a result for.
      * @param string $message
+     * @param string $class Class name to use (Either a FQCN, or a Cake style class)
      *
      * @return static
      */
@@ -78,7 +77,7 @@ abstract class Result implements ResultInterface
     /**
      * @return \DateTimeInterface|null
      */
-    public function getRecur()
+    public function getRecur(): ?\DateTimeInterface
     {
         return $this->_recur;
     }
@@ -87,7 +86,7 @@ abstract class Result implements ResultInterface
      * @param \DateTimeInterface|null $recur When to re-queue the job for.
      * @return static
      */
-    public function willRecur(\DateTimeInterface $recur = null)
+    public function willRecur(?\DateTimeInterface $recur)
     {
         $this->_recur = $recur;
 

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -9,6 +9,10 @@ use DelayedJobs\DelayedJob\Job;
  */
 abstract class Result implements ResultInterface
 {
+    const TYPE_FAILED = Failed::class;
+    const TYPE_SUCCESS = Success::class;
+    const TYPE_PAUSE = Pause::class;
+
     /**
      * @var string
      */
@@ -32,6 +36,25 @@ abstract class Result implements ResultInterface
     {
         $this->_message = $message;
         $this->_job = $job;
+    }
+
+    /**
+     * @param string $class Class name to use (Either a FQCN, or a Cake style class)
+     * @param \DelayedJobs\DelayedJob\Job $job Job this is a result for.
+     * @param string $message
+     *
+     * @return \DelayedJobs\Result\ResultInterface
+     */
+    public static function create(string $class, $message = ''): ResultInterface
+    {
+        $className = App::className($class, 'Result');
+        $result = new $className($message);
+
+        if (!$result instanceof ResultInterface) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" is not a valid %s instance.', $class, ResultInterface::class));
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Result/ResultInterface.php
+++ b/src/Result/ResultInterface.php
@@ -19,7 +19,7 @@ interface ResultInterface
     /**
      * @return \DateTimeInterface|null
      */
-    public function getRecur();
+    public function getRecur(): ?\DateTimeInterface;
 
     /**
      * @return bool
@@ -42,5 +42,5 @@ interface ResultInterface
      * @param \DateTimeInterface|null $recur When to re-queue the job for.
      * @return self
      */
-    public function willRecur(\DateTimeInterface $recur = null);
+    public function willRecur(?\DateTimeInterface $recur);
 }

--- a/src/Result/ResultInterface.php
+++ b/src/Result/ResultInterface.php
@@ -1,9 +1,6 @@
 <?php
 
 namespace DelayedJobs\Result;
-
-use DelayedJobs\DelayedJob\Job;
-
 /**
  * Interface ResultInterface
  */
@@ -20,11 +17,6 @@ interface ResultInterface
     public function getMessage(): string;
 
     /**
-     * @return \DelayedJobs\DelayedJob\Job
-     */
-    public function getJob(): Job;
-
-    /**
      * @return \DateTimeInterface|null
      */
     public function getRecur();
@@ -33,11 +25,6 @@ interface ResultInterface
      * @return bool
      */
     public function getRetry(): bool;
-
-    /**
-     * @return bool
-     */
-    public function canRetry(): bool;
 
     /**
      * @param bool $retry

--- a/src/Result/Success.php
+++ b/src/Result/Success.php
@@ -20,7 +20,7 @@ class Success extends Result
     /**
      * @return bool
      */
-    public function canRetry(): bool
+    public function getRetry(): bool
     {
         return false;
     }

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -364,13 +364,13 @@ class WorkerShell extends AppShell implements EventListenerInterface
 
     /**
      * @param \Cake\Event\Event $event
+     * @param \DelayedJobs\DelayedJob\Job $job
      * @param \DelayedJobs\Result\ResultInterface $result
      * @param $duration
      * @return void
      */
-    public function afterExecute(Event $event, ResultInterface $result, $duration)
+    public function afterExecute(Event $event, Job $job, ResultInterface $result, $duration)
     {
-        $job = $result->getJob();
         $this->_lastJob = $job->getId();
         $this->_jobCount++;
         $this->out('', 1, Shell::VERBOSE);

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -363,10 +363,10 @@ class WorkerShell extends AppShell implements EventListenerInterface
     }
 
     /**
-     * @param \Cake\Event\Event $event
-     * @param \DelayedJobs\DelayedJob\Job $job
-     * @param \DelayedJobs\Result\ResultInterface $result
-     * @param $duration
+     * @param \Cake\Event\Event $event The event
+     * @param \DelayedJobs\DelayedJob\Job $job The Job
+     * @param \DelayedJobs\Result\ResultInterface $result The result
+     * @param int $duration The duration
      * @return void
      */
     public function afterExecute(Event $event, Job $job, ResultInterface $result, $duration)

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -82,11 +82,12 @@ abstract class Worker implements JobWorkerInterface, EventDispatcherInterface, E
 
     /**
      * @param \Cake\Event\Event $event The event
+     * @param \DelayedJobs\DelayedJob\Job $job The job to run
      * @param \DelayedJobs\Result\ResultInterface $result The job result
      * @param int $duration The duration of the execution in milliseconds
      * @return void
      */
-    public function afterExecute(Event $event, ResultInterface $result, int $duration)
+    public function afterExecute(Event $event, Job $job, ResultInterface $result, int $duration)
     {
     }
 }


### PR DESCRIPTION
Cleans up the api for creating result objects and adds a utility `create()` static method to make it cleaner to use the fluid interface.