### PR TITLE
Add maxRetriesReached method to Job class

### DIFF
--- a/src/DelayedJob/Job.php
+++ b/src/DelayedJob/Job.php
@@ -776,4 +776,17 @@ class Job
 
         return $this;
     }
+
+    /**
+     * Check if max retries for the job has been reached.
+     *
+     * @return bool
+     */
+    public function maxRetriesReached(): bool
+    {
+        $jobRetries = $this->getRetries() + 1;
+        $maxRetries = $this->getMaxRetries();
+
+        return $jobRetries >= $maxRetries;
+    }
 }


### PR DESCRIPTION
This PR adds a useful `maxRetriesReached()` method to the `Job` class.